### PR TITLE
rename some things to avoid "line" related language

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
     - main
-  pull_request:
-    branches:
-    - main
+  pull_request: []
 jobs:
   build:
     name: Build & Test

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Run `make` and the shared library will available be at `./build/flite.so`.
 
 ## lines
 
-`lines` is an [eponoymous-only virtual table](https://www.sqlite.org/vtab.html#eponymous_only_virtual_tables) (table-valued-function) that reads a file from disk (or stdin if no file is specified) by line.
+`split` is an [eponoymous-only virtual table](https://www.sqlite.org/vtab.html#eponymous_only_virtual_tables) (table-valued-function) that reads a file from disk (or stdin if no file is specified) and splits it into rows by a delimiter (defaults to `\n`).
 
 ```sql
-SELECT * FROM lines("/path/to/some/file.ndjson")
+SELECT * FROM split("/path/to/some/file.ndjson")
 ```
 
 ## readfile

--- a/internal/split/iter.go
+++ b/internal/split/iter.go
@@ -12,11 +12,11 @@ import (
 )
 
 type iter struct {
-	filePath      string
-	file          *os.File
-	scanner       *bufio.Scanner
-	currentLineNo int
-	delimiter     string
+	filePath  string
+	file      *os.File
+	scanner   *bufio.Scanner
+	index     int
+	delimiter string
 }
 
 // taken from bufio/scan.go
@@ -48,6 +48,7 @@ func newIter(filePath string, delimiter string) (*iter, error) {
 	} else {
 		f = os.Stdin
 	}
+
 	split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil
@@ -68,18 +69,18 @@ func newIter(filePath string, delimiter string) (*iter, error) {
 	scanner.Buffer(buf, 0)
 
 	return &iter{
-		filePath:      absPath,
-		file:          f,
-		scanner:       scanner,
-		currentLineNo: 0,
-		delimiter:     delimiter,
+		filePath:  absPath,
+		file:      f,
+		scanner:   scanner,
+		index:     -1,
+		delimiter: delimiter,
 	}, nil
 }
 
 func (i *iter) Column(c int) (interface{}, error) {
 	switch c {
 	case 0:
-		return i.currentLineNo, nil
+		return i.index, nil
 	case 1:
 		return i.scanner.Text(), nil
 	case 2:
@@ -92,7 +93,7 @@ func (i *iter) Column(c int) (interface{}, error) {
 }
 
 func (i *iter) Next() (vtab.Row, error) {
-	i.currentLineNo++
+	i.index++
 	keepGoing := i.scanner.Scan()
 	if !keepGoing {
 		err := i.scanner.Err()

--- a/internal/split/iter_test.go
+++ b/internal/split/iter_test.go
@@ -24,11 +24,11 @@ func TestSingleLineIter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		lineNo, err := row.Column(0)
+		lineIdx, err := row.Column(0)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if lineNo != 1 {
+		if lineIdx != 0 {
 			t.Fatalf("unexpected line no")
 		}
 
@@ -63,7 +63,7 @@ func TestMultiLineIter(t *testing.T) {
 	}
 
 	expectedLines := strings.Split(string(contentBytes), "\n")
-	expectedLineNo := 1
+	expectedLineIdx := 0
 	for {
 		row, err := i.Next()
 		if err != nil {
@@ -73,21 +73,21 @@ func TestMultiLineIter(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		lineNo, err := row.Column(0)
+		lineIdx, err := row.Column(0)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if lineNo != expectedLineNo {
+		if lineIdx != expectedLineIdx {
 			t.Fatalf("unexpected line no")
 		}
-		expectedLineNo++
+		expectedLineIdx++
 
 		line, err := row.Column(1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		expectedLine := expectedLines[lineNo.(int)-1]
+		expectedLine := expectedLines[lineIdx.(int)]
 		if line != expectedLine {
 			t.Fatalf("unexpected line contents, want: %s got: %s", expectedLine, line)
 		}


### PR DESCRIPTION
just a bit of renaming `line` -> `index` since it's now a more generic split function (before, "lines" started at 1, indexes sound like they should start at 0)